### PR TITLE
Fix xrange() function error

### DIFF
--- a/report/pdf/charts/pie.py
+++ b/report/pdf/charts/pie.py
@@ -76,11 +76,11 @@ class BreakdownPieDrawing(_DrawingEditorMixin, Drawing):
         n = len(self.pie.data)
         self.set_items(n, self.pie.slices, 'fillColor', pdf_chart_colors)
         self.legend.colorNamePairs = [
-            (self.pie.slices[i].fillColor, (self.pie.labels[i][0:20], '%0.2f' % data[i])) for i in xrange(n)]
+            (self.pie.slices[i].fillColor, (self.pie.labels[i][0:20], '%0.2f' % data[i])) for i in range(n)]
 
     @staticmethod
     def set_items(n, obj, attr, values):
         m = len(values)
         i = m // n
-        for j in xrange(n):
+        for j in range(n):
             setattr(obj[j], attr, values[j * i % m])


### PR DESCRIPTION
Fixed error that my windows 10 python 3.7 install hit every time it tried to run the xrange() function.