### PR TITLE
update requirements for latest yffpy changes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-yffpy>=2.0.0
+yffpy>=2.6.0
 yahoo_oauth==0.1.9
 reportlab==3.3.0
 pillow==5.4.1


### PR DESCRIPTION
Because the data model changed for yffpy, the yahoo report was failing because `faab_balance` didnt exist.  

update requirements.txt to up the required version to 2.6 which introduces the change.  