### PR TITLE
Add additional superflex handling to fix coaching efficiency

### DIFF
--- a/calculate/coaching_efficiency.py
+++ b/calculate/coaching_efficiency.py
@@ -15,8 +15,10 @@ class CoachingEfficiency(object):
 
         self.roster_slot_counts = roster_settings["position_counts"]
         self.roster_active_slots = roster_settings["positions_active"]
+        # TODO: support different types of flex (WR/TE, etc.)
         self.flex_positions = {
-            "FLEX": roster_settings["positions_flex"]
+            "FLEX": roster_settings["positions_flex"],
+            "SUPER_FLEX": roster_settings["positions_super_flex"]
         }
 
         flex_def_positions = ["DB", "DL", "LB", "DT", "DE", "S", "CB"]

--- a/calculate/points_by_position.py
+++ b/calculate/points_by_position.py
@@ -55,6 +55,7 @@ class PointsByPosition(object):
         player_points_by_position = []
         starting_players = [p for p in roster if p.selected_position not in self.bench_positions]
         for slot in list(self.roster_slot_counts.keys()):
+            # TODO: support different variations of FLEX (WR/RB, WR/RB/TE, WR/TE, etc.) separately
             if slot not in self.bench_positions and slot not in ["FLEX", "SUPER_FLEX"]:
                 player_points_by_position.append([slot, self.get_points_for_position(starting_players, slot)])
 

--- a/dao/base.py
+++ b/dao/base.py
@@ -107,6 +107,7 @@ class BaseLeague(FantasyFootballReportObject):
         self.roster_position_counts = defaultdict(int)
         self.active_positions = []
         self.flex_positions = []
+        self.super_flex_positions = []
 
         self.matchups_by_week = {}
         self.teams_by_week = {}
@@ -183,6 +184,7 @@ class BaseLeague(FantasyFootballReportObject):
             "position_counts": self.roster_position_counts,
             "positions_active": self.active_positions,
             "positions_flex": self.flex_positions,
+            "positions_super_flex": self.super_flex_positions,
             "positions_bench": self.bench_positions
         }
 

--- a/dao/espn.py
+++ b/dao/espn.py
@@ -161,13 +161,13 @@ class LeagueData(object):
 
             if pos_name == "RB/WR":
                 league.flex_positions = ["RB", "WR"]
+                pos_name = "FLEX"
             if pos_name == "RB/WR/TE":
                 league.flex_positions = ["RB", "WR", "TE"]
-            if pos_name == "QB/RB/WR/TE":
-                league.flex_positions = ["QB", "RB", "Wr", "TE"]
-
-            if "/" in pos_name and pos_name != "D/ST":
                 pos_name = "FLEX"
+            if pos_name == "QB/RB/WR/TE":
+                league.super_flex_positions = ["QB", "RB", "Wr", "TE"]
+                pos_name = "SUPER_FLEX"
 
             league.roster_positions.append(pos_name)
             league.roster_position_counts[pos_name] = int(count)

--- a/dao/fleaflicker.py
+++ b/dao/fleaflicker.py
@@ -282,13 +282,13 @@ class LeagueData(object):
 
             if pos_name == "RB/WR":
                 league.flex_positions = ["WR", "RB"]
+                pos_name = "FLEX"
             if pos_name == "RB/WR/TE":
                 league.flex_positions = ["WR", "RB", "TE"]
-            if pos_name == "RB/WR/TE/QB":
-                league.flex_positions = ["QB", "WR", "RB", "TE"]
-
-            if pos_name != "D/ST" and "/" in pos_name:
                 pos_name = "FLEX"
+            if pos_name == "RB/WR/TE/QB":
+                league.super_flex_positions = ["QB", "WR", "RB", "TE"]
+                pos_name = "SUPER_FLEX"
 
             league.roster_positions.append(pos_name)
             league.roster_position_counts[pos_name] = pos_count

--- a/dao/sleeper.py
+++ b/dao/sleeper.py
@@ -293,13 +293,9 @@ class LeagueData(object):
             #     league.flex_positions = ["WR", "RB"]
             # TODO: how to tell the difference when player starting positions are not specified?
             if pos_name == "FLEX":
-                flex_positions = ["WR", "RB", "TE"]
-                if len(flex_positions) > len(league.flex_positions):
-                    league.flex_positions = flex_positions
-            elif pos_name == "SUPER_FLEX":
-                flex_positions = ["QB", "WR", "RB", "TE"]
-                if len(flex_positions) > len(league.flex_positions):
-                    league.flex_positions = flex_positions
+                league.flex_positions = ["WR", "RB", "TE"]
+            if pos_name == "SUPER_FLEX":
+                league.super_flex_positions = ["QB", "WR", "RB", "TE"]
 
             # if pos_name != "D/ST" and "/" in pos_name:
             #     pos_name = "FLEX"

--- a/dao/yahoo.py
+++ b/dao/yahoo.py
@@ -207,13 +207,13 @@ class LeagueData(object):
 
             if pos_name == "W/R":
                 league.flex_positions = ["WR", "RB"]
+                pos_name = "FLEX"
             if pos_name == "W/R/T":
                 league.flex_positions = ["WR", "RB", "TE"]
-            if pos_name == "Q/W/R/T":
-                league.flex_positions = ["QB", "WR", "RB", "TE"]
-
-            if "/" in pos_name:
                 pos_name = "FLEX"
+            if pos_name == "Q/W/R/T":
+                league.super_flex_positions = ["QB", "WR", "RB", "TE"]
+                pos_name = "SUPER_FLEX"
 
             league.roster_positions.append(pos_name)
             league.roster_position_counts[pos_name] = pos_count

--- a/report/builder.py
+++ b/report/builder.py
@@ -324,9 +324,10 @@ class FantasyFootballReport(object):
             self.league.name + " (" + str(self.league_id) + ") Week " + \
             str(self.league.week_for_report) + " Report"
         report_footer_text = \
-            "<para alignment='center'>Report generated %s for %s Fantasy Football league '%s' (%s).</para>" % \
+            "<para alignment='center'>Report generated %s for %s Fantasy Football league '%s' with id %s " \
+            "(<a href=\"%s\" color=blue><u>%s</u></a>).</para>" % \
             ("{:%Y-%b-%d %H:%M:%S}".format(datetime.datetime.now()), self.platform_str, self.league.name,
-             self.league_id)
+             self.league_id, self.league.url, self.league.url)
 
         if not os.path.isdir(report_save_dir):
             os.makedirs(report_save_dir)


### PR DESCRIPTION
Variations of the flex position continue to plague proper coaching efficiency calculations... the CE calcs will almost assuredly break again if the report app is run against a league with multiple types of regular flex (so if there is a WR/RB AND a WR/RB/TE) in the same lineup, but I will cross that bridge when I come to it. 

In the meantime, this should fix things for leagues with superflex, and closes #74 