### PR TITLE
Add support for multiple flex types and fix CE bugs across platforms

### DIFF
--- a/EXAMPLE-config.ini
+++ b/EXAMPLE-config.ini
@@ -30,10 +30,6 @@ week_for_report = default
 ; improves the quality of the playoff predictions, it also make this step of the report take longer to complete
 num_playoff_simulations = 100000
 
-; player bench positions for league/platform
-; (comma-delimited list with no spaces)
-bench_positions = BN,IR
-
 ; prohibited player statuses to check team coaching efficiency eligibility (if dq_ce = True)
 ; (comma-delimited list with no spaces)
 prohibited_statuses = PUP-P,SUSP,O,IR,INACTIVE,IR-R

--- a/calculate/metrics.py
+++ b/calculate/metrics.py
@@ -377,7 +377,7 @@ class CalculateMetrics(object):
 
         if league.player_data_by_week_function:
             coaching_efficiency_results_data_with_tiebreakers = []
-            bench_positions = league.get_roster_slots_by_type().get("positions_bench")
+            bench_positions = league.bench_positions
 
             season_average_points_by_player_dict = defaultdict(list)
             if break_ties and ties_for_coaching_efficiency > 0 and int(week) == int(week_for_report):

--- a/calculate/points_by_position.py
+++ b/calculate/points_by_position.py
@@ -3,22 +3,19 @@ __email__ = "wrenjr@yahoo.com"
 
 import copy
 
-from dao.base import BaseTeam, BasePlayer
+from dao.base import BaseLeague, BaseTeam, BasePlayer
 from report.logger import get_logger
 
 logger = get_logger(__name__)
 
 
 class PointsByPosition(object):
-    def __init__(self, roster_settings, week_for_report):
+    def __init__(self, league: BaseLeague, week_for_report):
 
         self.week_for_report = week_for_report
-        self.roster_slot_counts = roster_settings.get("position_counts")
-        self.flex_positions = {
-            "FLEX": roster_settings["positions_flex"],
-            "D": ["D", "DB", "DL", "LB", "DT", "DE", "S", "CB"]
-        }
-        self.bench_positions = roster_settings.get("positions_bench")
+        self.roster_slot_counts = league.roster_position_counts
+        self.bench_positions = league.bench_positions
+        self.flex_types = list(league.get_flex_positions_dict().keys())
 
     def get_points_for_position(self, players, position):
         total_points_by_position = 0
@@ -55,8 +52,7 @@ class PointsByPosition(object):
         player_points_by_position = []
         starting_players = [p for p in roster if p.selected_position not in self.bench_positions]
         for slot in list(self.roster_slot_counts.keys()):
-            # TODO: support different variations of FLEX (WR/RB, WR/RB/TE, WR/TE, etc.) separately
-            if slot not in self.bench_positions and slot not in ["FLEX", "SUPER_FLEX"]:
+            if slot not in self.bench_positions and slot not in self.flex_types:
                 player_points_by_position.append([slot, self.get_points_for_position(starting_players, slot)])
 
         player_points_by_position = sorted(player_points_by_position, key=lambda x: x[0])

--- a/dao/base.py
+++ b/dao/base.py
@@ -109,8 +109,11 @@ class BaseLeague(FantasyFootballReportObject):
         self.roster_positions = []
         self.roster_position_counts = defaultdict(int)
         self.active_positions = []
-        self.flex_positions = []
-        self.super_flex_positions = []
+        self.flex_positions_rb_wr = []
+        self.flex_positions_te_wr = []
+        self.flex_positions_rb_te_wr = []
+        self.flex_positions_qb_rb_te_wr = []
+        self.flex_positions_idp = []
 
         self.matchups_by_week = {}
         self.teams_by_week = {}
@@ -188,13 +191,13 @@ class BaseLeague(FantasyFootballReportObject):
             matchup_list.append(teams)
         return matchup_list
 
-    def get_roster_slots_by_type(self):
+    def get_flex_positions_dict(self):
         return {
-            "position_counts": self.roster_position_counts,
-            "positions_active": self.active_positions,
-            "positions_flex": self.flex_positions,
-            "positions_super_flex": self.super_flex_positions,
-            "positions_bench": self.bench_positions
+            "FLEX_RB_WR": self.flex_positions_rb_wr,
+            "FLEX_TE_WR": self.flex_positions_te_wr,
+            "FLEX_RB_TE_WR": self.flex_positions_rb_te_wr,
+            "FLEX_QB_RB_TE_WR": self.flex_positions_qb_rb_te_wr,
+            "FLEX_IDP": self.flex_positions_idp
         }
 
     def get_playoff_probs(self, save_data=False, playoff_prob_sims=None, dev_offline=False, recalculate=True):

--- a/dao/utils.py
+++ b/dao/utils.py
@@ -160,7 +160,7 @@ def add_report_player_stats(player,  # type: BasePlayer
 def add_report_team_stats(team: BaseTeam, league: BaseLeague, week_counter, metrics_calculator, metrics, dq_ce,
                           inactive_players) -> BaseTeam:
     team.name = metrics_calculator.decode_byte_string(team.name)
-    bench_positions = league.get_roster_slots_by_type().get("positions_bench")
+    bench_positions = league.bench_positions
 
     for player in team.roster:
         add_report_player_stats(player, bench_positions, metrics)

--- a/report/builder.py
+++ b/report/builder.py
@@ -180,7 +180,7 @@ class FantasyFootballReport(object):
                 week_for_report=week_for_report,
                 metrics_calculator=metrics_calculator,
                 metrics={
-                    "coaching_efficiency": CoachingEfficiency(self.config, self.league.get_roster_slots_by_type()),
+                    "coaching_efficiency": CoachingEfficiency(self.config, self.league),
                     "luck": metrics_calculator.calculate_luck(
                         self.league.teams_by_week.get(str(week_counter)),
                         custom_weekly_matchups

--- a/report/data.py
+++ b/report/data.py
@@ -152,8 +152,8 @@ class ReportData(object):
                 z_score_rank += 1
 
         # points by position data
-        point_by_position = PointsByPosition(league.get_roster_slots_by_type(), week_for_report)
-        self.data_for_weekly_points_by_position = point_by_position.get_weekly_points_by_position(self.teams_results)
+        points_by_position = PointsByPosition(league, week_for_report)
+        self.data_for_weekly_points_by_position = points_by_position.get_weekly_points_by_position(self.teams_results)
 
         # teams data and season average points by position data
         self.data_for_teams = []
@@ -298,7 +298,7 @@ class ReportData(object):
                     ce_dq_str += "{} (ineligible bench players: {}/{}), ".format(
                         team_name,
                         ineligible_players_count,
-                        league.get_roster_slots_by_type().get("position_counts").get("BN"))
+                        league.roster_position_counts.get("BN"))  # exclude IR
             weekly_metrics_output_string += "   COACHING EFFICIENCY DQs: {}\n".format(ce_dq_str[:-2])
 
         # output weekly metrics info

--- a/report/pdf/charts/line.py
+++ b/report/pdf/charts/line.py
@@ -56,20 +56,20 @@ class LineChartGenerator(_DrawingEditorMixin, Drawing):
         self.chart.lines.strokeWidth = 2
 
         self.legend.colorNamePairs = Auto(obj=self.chart)
-        self.legend.x = 10
-        self.legend.y = 30
+        self.legend.x = 10 * (len(series_names) // 5)  # adjust how far to the left/right the legend labels are
+        self.legend.y = 12 * (len(series_names) // 5)  # adjust how far up/down the legend labels are
         # set size of swatches
         self.legend.dx = 0
         self.legend.dy = -5
         self.legend.fontName = font
-        self.legend.fontSize = 8 if len(series_names) % 3 == 0 else 7
+        self.legend.fontSize = 100 // len(series_names)
         self.legend.alignment = "right"
-        self.legend.columnMaximum = 2 if len(series_names) % 3 == 0 else 3
+        self.legend.columnMaximum = (len(series_names) // 5) + 1  # adjust number of ROWS allowed in legend
         self.legend.dxTextSpace = 4
         self.legend.variColumn = 1
         self.legend.boxAnchor = "nw"
-        self.legend.deltay = 10
-        self.legend.autoXPadding = 20
+        self.legend.deltay = 10  # adjust the space between legend rows
+        self.legend.autoXPadding = 15 * ((len(series_names) // 5) + 1)  # adjust the space between legend columns
 
         self.background = Rect(0, 0, self.width, self.height, strokeWidth=0, fillColor=PCMYKColor(0, 0, 10, 0))
         self.background.strokeColor = black

--- a/report/pdf/generator.py
+++ b/report/pdf/generator.py
@@ -523,19 +523,15 @@ class PdfGenerator(object):
             cow_icon = self.get_img(os.path.join("resources", "images", "cow.png"), width=0.20 * inch)
             beef_icon = self.get_img(os.path.join("resources", "images", "beef.png"), width=0.20 * inch)
             half_beef_icon = self.get_img(os.path.join("resources", "images", "beef-half.png"), width=0.10 * inch)
-            # lowest_tabbu = float(data[-1][3])
-            # mod_5_remainder = lowest_tabbu % 5
-            # beef_count_floor = lowest_tabbu - mod_5_remainder
 
             for team in data:
-                num_cows = int(float(team[3]) // 5) - 1  # subtract one to make sure there are always beef icons
+                num_cows = int(float(team[3]) // 5)
                 num_beefs = int(float(team[3]) / 0.5) - (num_cows * 10)
-                # num_beefs = int((float(team[3]) - beef_count_floor) / 0.5) - (num_cows * 10)
 
                 if num_cows > 0:
-                    beefs = [cow_icon] * num_cows
+                    num_beefs += 10
+                    beefs = [cow_icon] * (num_cows - 1)  # subtract one to make sure there are always beef icons
                 else:
-                    num_beefs = num_beefs - 10
                     beefs = []
 
                 if num_beefs % 2 == 0:
@@ -722,11 +718,6 @@ class PdfGenerator(object):
             chart_width,
             chart_height
         )
-        # points_line_chart.make_title(chart_title)
-        # points_line_chart.make_data(data)
-        # points_line_chart.make_x_axis(x_axis_title, 0, data_length + 1, 1)
-        # points_line_chart.make_y_axis(y_axis_title, values_min, values_max, y_step)
-        # points_line_chart.make_series_labels(series_names)
 
         return points_line_chart
 
@@ -857,13 +848,15 @@ class PdfGenerator(object):
                                                          self.week_for_report, 1.5 * inch,
                                                          worst_weekly_player.full_name)
 
-                data = [["BOOOOOOOOM", "...b... U... s... T"],
-                        [best_weekly_player.full_name + " -- " + (best_weekly_player.nfl_team_name if
-                         best_weekly_player.nfl_team_name else "N/A"),
-                         worst_weekly_player.full_name + " -- " + (worst_weekly_player.nfl_team_name if
-                         worst_weekly_player.nfl_team_name else "N/A")],
-                        [best_player_headshot, worst_player_headshot],
-                        [best_weekly_player.points, worst_weekly_player.points]]
+                data = [
+                    ["BOOOOOOOOM", "...b... U... s... T"],
+                    [best_weekly_player.full_name + " -- " + (best_weekly_player.nfl_team_name if
+                     best_weekly_player.nfl_team_name else "N/A"),
+                     worst_weekly_player.full_name + " -- " + (worst_weekly_player.nfl_team_name if
+                     worst_weekly_player.nfl_team_name else "N/A")],
+                    [best_player_headshot, worst_player_headshot],
+                    [round(best_weekly_player.points, 2), round(worst_weekly_player.points, 2)]
+                ]
                 # TODO: figure out how to get player points from weeks they were not started or on roster
                 # ["{} ({} avg: +{}%)".format(
                 #     round(best_weekly_player.points, 2),


### PR DESCRIPTION
Previously there was only support for some subset of WR/RB, WR/TE, WR/RB/TE and QB/WR/RB/TE flex positions across the various supported platforms. This adds support for all of them, as well as fixes coaching efficiency bugs that were present in several places, most notably for ESPN leagues.

Closes #77 

Closes #81 