### PR TITLE
Sleeper leagues missing playoff start

### DIFF
--- a/dao/sleeper.py
+++ b/dao/sleeper.py
@@ -70,7 +70,9 @@ class LeagueData(object):
         self.week_for_report = week_validation_function(self.config, week_for_report, self.current_week, self.season)
 
         self.num_playoff_slots = self.league_settings.get("playoff_teams")
-        self.num_regular_season_weeks = int(self.league_settings.get("playoff_week_start")) - 1
+        self.num_regular_season_weeks = (int(self.league_settings.get("playoff_week_start")) - 1) \
+            if self.league_settings.get("playoff_week_start") > 0 \
+            else self.config.get("Configuration", "num_regular_season_weeks")
         self.roster_positions = dict(Counter(self.league_info.get("roster_positions")))
         self.has_median_matchup = bool(self.league_settings.get("league_average_match"))
         self.median_score_by_week = {}


### PR DESCRIPTION
When Sleeper leagues do not have a playoff start (but still have playoffs), then the report now defaults to the config.ini value for number of regular season weeks.

Closes #116 