### PR TITLE
Fix issue with Sleeper Players with Multiple Eligible Positions

### DIFF
--- a/calculate/metrics.py
+++ b/calculate/metrics.py
@@ -563,7 +563,7 @@ class CalculateMetrics(object):
                     place += 1
             return resolved_coaching_efficiency_results_data
         else:
-            logger.warning(
+            logger.debug(
                 "No function to retrieve past player weekly points available. Cannot resolve coaching efficiency ties.")
             return data_for_coaching_efficiency
 

--- a/dao/platforms/fleaflicker.py
+++ b/dao/platforms/fleaflicker.py
@@ -46,7 +46,7 @@ class LeagueData(object):
         self.save_data = save_data
         self.dev_offline = dev_offline
 
-        self.offensive_positions = ["QB", "RB", "WR", "TE", "K", "RB/WR/TE"]
+        self.offensive_positions = ["QB", "RB", "WR", "TE", "K", "RB/WR", "WR/TE", "RB/WR/TE", "RB/WR/TE/QB"]
         self.defensive_positions = ["D/ST"]
 
         # create full directory path if any directories in it do not already exist

--- a/utils/report_tools.py
+++ b/utils/report_tools.py
@@ -556,8 +556,8 @@ def add_report_team_stats(config, team: BaseTeam, league: BaseLeague, week_count
     # confirm total starting lineup points is the same as team points
     if round(team.points, 2) != (starting_lineup_points + team.home_field_advantage):
         logger.warning(
-            "Team {0} points ({1}) are not equal to sum of team starting lineup points ({2}). Check data!".format(
-                team.name, round(team.points, 2), starting_lineup_points))
+            "Team {0} retrieved points ({1}) are not equal to calculated sum of team starting lineup points ({2}). "
+            "Check data!".format(team.name, round(team.points, 2), starting_lineup_points))
 
     team.bench_points = round(sum([p.points for p in team.roster if p.selected_position in bench_positions]), 2)
 


### PR DESCRIPTION
When players on Sleeper had multiple eligible positions, sometimes they would get assigned to a roster slot that was actually occupied by a different player due to the multiple position player having a different primary position than the one they were occupying. This PR moves those players to the end of the processing queue so that they are processed last, allowing players with more limited positions to get processed first.

Note: This is likely an imperfect fix as there are still edge cases where this issue could arise, but this should greatly limit the occurrence of the report breaking issue.

Closes #132 