### PR TITLE
Use new ESPN fantasy endpoint via espn-api==0.36.0

### DIFF
--- a/dao/platforms/espn.py
+++ b/dao/platforms/espn.py
@@ -54,7 +54,7 @@ class LeagueData(BaseLeagueData):
                  week_validation_function: Callable, save_data: bool = True, offline: bool = False):
         super().__init__(
             "ESPN",
-            "https://fantasy.espn.com",
+            "https://lm-api-reads.fantasy.espn.com",
             base_dir,
             data_dir,
             league_id,
@@ -411,7 +411,7 @@ class LeagueData(BaseLeagueData):
                                 - int(team_json["transactionCounter"].get("acquisitionBudgetSpent", 0))
                         )
                     base_team.url = (
-                        f"https://fantasy.espn.com/football/team"
+                        f"https://lm-api-reads.fantasy.espn.com/football/team"
                         f"?leagueId={self.league.league_id}&teamId={base_team.team_id}"
                     )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 beautifulsoup4==4.12.2
 camel-converter==3.1.1
 colorama==0.4.6
-espn-api==0.33.0
+espn-api==0.36.0
 GitPython==3.1.40
 google-api-python-client==2.109.0
 httplib2==0.22.0


### PR DESCRIPTION
This combined with the changes from https://github.com/uberfastman/fantasy-football-metrics-weekly-report/pull/210 is enough to generate an ESPN report.

0.36.0 isn't the latest version but is the first version with the updated API endpoint. See https://github.com/cwendt94/espn-api/releases/tag/v0.36.0

Double checking the output the beef rankings don't seem right. None of the scores are over 4 and for most of my other leagues they're around 18+.