### PR TITLE
Calculated and added Season Total Rankings for Optimal Points section

### DIFF
--- a/report/builder.py
+++ b/report/builder.py
@@ -329,10 +329,15 @@ class FantasyFootballReport(object):
                     team_luck_data_entry.append(team.weekly_overall_record.get_record_str())
 
         # add season total optimal points to optimal points data
+        sorted_season_total_optimal_points_data = dict(sorted(season_total_optimal_points_data.items(), key=lambda x: x[1], reverse=True))
+        list_sorted_season_total_optimal_points_data = [(i, k, v) for i, (k, v) in enumerate(sorted_season_total_optimal_points_data.items())]
         for team_optimal_points_data_entry in report_data.data_for_optimal_scores:
-            for team_name, season_total_optimal_points in season_total_optimal_points_data.items():
+            for team_index, team_name, season_total_optimal_points in list_sorted_season_total_optimal_points_data:
                 if team_optimal_points_data_entry[1] == team_name:
-                    team_optimal_points_data_entry.append(f"{round(season_total_optimal_points, 2):.2f}")
+                    place = team_index + 1
+                    total_optimal_points_ranked = str("{:.2f}".format(round(season_total_optimal_points, 2))) + " (" + str(place) +")"
+                    team_optimal_points_data_entry.append(total_optimal_points_ranked)
+
 
         report_data.data_for_power_rankings = season_average_calculator.get_average(
             time_series_power_rank_data,

--- a/report/pdf/generator.py
+++ b/report/pdf/generator.py
@@ -435,7 +435,7 @@ class PdfGenerator(object):
         self.scores_headers = [["Place", "Team", "Manager", "Points", "Season Avg. (Place)"]]
         self.efficiency_headers = [["Place", "Team", "Manager", "Coaching Efficiency (%)", "Season Avg. (Place)"]]
         self.luck_headers = [["Place", "Team", "Manager", "Luck", "Season Avg. (Place)", "Weekly Record (W-L)"]]
-        self.optimal_scores_headers = [["Place", "Team", "Manager", "Optimal Points", "Season Total"]]
+        self.optimal_scores_headers = [["Place", "Team", "Manager", "Optimal Points", "Season Total (Place)"]]
         self.bad_boy_headers = [["Place", "Team", "Manager", "Bad Boy Pts", "Worst Offense", "# Offenders"]]
         self.beef_headers = [["Place", "Team", "Manager", "TABBU(s)"]]
         self.high_roller_headers = [[


### PR DESCRIPTION
This feature enhances the Team Optimal Score Rankings section by adding an additional summary ranking of the the Season Total Optimal Points. This allows not only a sorted view of Weekly Optimal Points, but the Season Total Optimal Points now also has respective "rank/place" as well for easy comparison of 1-N for the league for Optimal Points in the same table/section.