### PR TITLE
Updated Weekly Luck Record function to also calculate and report Season Luck Record and Ranking/Place

### DIFF
--- a/report/pdf/generator.py
+++ b/report/pdf/generator.py
@@ -435,7 +435,7 @@ class PdfGenerator(object):
         self.zscores_headers = [["Place", "Team", "Manager", "Z-Score"]]
         self.scores_headers = [["Place", "Team", "Manager", "Points", "Season Avg. (Place)"]]
         self.efficiency_headers = [["Place", "Team", "Manager", "Coaching Efficiency (%)", "Season Avg. (Place)"]]
-        self.luck_headers = [["Place", "Team", "Manager", "Luck", "Season Avg. (Place)", "Weekly Record (W-L)"]]
+        self.luck_headers = [["Place", "Team", "Manager", "Luck", "Season Avg. (Place)", "Week/Seas Rec. (Pl.)"]]
         self.optimal_scores_headers = [["Place", "Team", "Manager", "Optimal Points", "Season Total (Place)"]]
         self.bad_boy_headers = [["Place", "Team", "Manager", "Bad Boy Pts", "Worst Offense", "# Offenders"]]
         self.beef_headers = [["Place", "Team", "Manager", "TABBU(s)"]]


### PR DESCRIPTION
This feature enhances the Team Luck Rankings section by adding a Season Record for Luck in addition to the Weekly Record for Luck. On top of that it also calculates the Season Ranking/Place for the Season Record. With this feature the last column of the Team Luck Rankings now provides 3 distinct data points:

- Weekly Luck Record
- Season Luck Record
- Season Luck Rank

This allows for a very useful analysis of what a record would look like for everyone in a league if you eliminated the positive/negative luck. Probably the most useful comparison that can be made of what a team's record would really look like compared to everyone else if you eliminate luck as a variable.